### PR TITLE
Fix confirmation of emails when the submit button is image

### DIFF
--- a/trust-form.php
+++ b/trust-form.php
@@ -2338,7 +2338,7 @@ class Trust_Form_Front {
 						$this->err_msg[$key][] = $Trust_Form_Validator_Message['required'];
 					if ( $_POST[$key] != "" && !is_email($_POST[$key]) )
 						$this->err_msg[$key][] = $Trust_Form_Validator_Message['e-mail'];
-					if ( isset( $_POST['send-to-confirm'] ) && isset($this->validate[0][$key]['e_mail_confirm']) && $this->validate[0][$key]['e_mail_confirm'] != '' ) {
+					if ( ( isset( $_POST['send-to-confirm'] ) || isset( $_POST['send-to-confirm_x'] ) ) && isset($this->validate[0][$key]['e_mail_confirm']) && $this->validate[0][$key]['e_mail_confirm'] != '' ) {
 						foreach ( $this->name[0] as $key_1 => $name_1 ) {
 							if ( $this->validate[0][$key]['e_mail_confirm'] == $name_1 ) {
 								if ( $_POST[$key] != $_POST[$key_1] )


### PR DESCRIPTION
Problem
-------

Confirmation of email does not work when the submit button is image.

Suppose that we have a form having the following fields:

* Email
    * type: E-Mail
    * required: true
    * confirm title: "Confirm Email"
* Confirm Email
    * type: E-Mail
    * required: true
* Submit Button
    * Use button image

When a user enters two different emails and then click the submit button, they see no error and proceed to the confirm screen.

Expected Behavior
-----------------

When the user click the submit button, they see an error message "The e-mail mismatch".

Solution
--------

Both send-to-confirm and send-to-confirm_x should be checked.