### PR TITLE
Fix the selectbox bug in admin screen

### DIFF
--- a/js/add-form.js
+++ b/js/add-form.js
@@ -342,6 +342,7 @@ var addTrustForm,TR_element_count = 0;
 
 						var p = t.val(), tmp = '';
 
+                        w = t.parent().parent().parent().find('input[name=selectbox-default-value]').val();
 						p = p.replace(/\r/g, '');
 						p = p.split(/\n/g);
 


### PR DESCRIPTION
管理画面にて、セレクトボックスの値を入力するフィールドにフォーカスを合わせると
デフォルト値が'option-value'となってしまう問題を解決
